### PR TITLE
Day-of-the-programmer solution in c++

### DIFF
--- a/Hackerrank/Day of the programmer/day_of_the_programmer.cpp
+++ b/Hackerrank/Day of the programmer/day_of_the_programmer.cpp
@@ -13,10 +13,14 @@ string dayOfProgrammer(int year) {
     {
         return "26.09.1918";
     }
+
     else if((year<1918 && year%4==0) ||(year>1918  &&(year%4==0 && year%100 !=0 || year%400==0))) 
     {
         return "12.09." + to_string(year);
+
+        //to_string is used to convert int into a string
     }
+
     else
     {
         return "13.09." + to_string(year);
@@ -27,17 +31,26 @@ string dayOfProgrammer(int year) {
 //main function
 int main()
 {
+    //opening file
     ofstream fout(getenv("OUTPUT_PATH"));
 
+    //declaration of string 
     string year_temp;
+
+    //taking input  of the year in string data type 
     getline(cin, year_temp);
 
+    // stoi: converting input string into integer
+    // rtrim and ltrim : for removing whitespaces from left and right of the string  
     int year = stoi(ltrim(rtrim(year_temp)));
 
+    //passing it to dayofprogrammer function 
     string result = dayOfProgrammer(year);
 
+    //printing result 
     fout << result << "\n";
 
+    //closing file
     fout.close();
 
     return 0;
@@ -47,6 +60,7 @@ int main()
 string ltrim(const string &str) {
     string s(str);
 
+    //triming the 'year' string from start by using these inbuilt funtions
     s.erase(
         s.begin(),
         find_if(s.begin(), s.end(), not1(ptr_fun<int, int>(isspace)))
@@ -59,6 +73,7 @@ string ltrim(const string &str) {
 string rtrim(const string &str) {
     string s(str);
 
+    //triming the 'year' string from end by using these inbuilt funtions
     s.erase(
         find_if(s.rbegin(), s.rend(), not1(ptr_fun<int, int>(isspace))).base(),
         s.end()

--- a/Hackerrank/day-of-the-programmer/day_of_the_programmer.cpp
+++ b/Hackerrank/day-of-the-programmer/day_of_the_programmer.cpp
@@ -1,0 +1,68 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+//function prototypes
+string ltrim(const string &);
+string rtrim(const string &);
+
+// definition of dayOfProgrammer function below.
+string dayOfProgrammer(int year) {
+
+  if(year==1918)
+    {
+        return "26.09.1918";
+    }
+    else if((year<1918 && year%4==0) ||(year>1918  &&(year%4==0 && year%100 !=0 || year%400==0))) 
+    {
+        return "12.09." + to_string(year);
+    }
+    else
+    {
+        return "13.09." + to_string(year);
+    }
+
+}
+
+//main function
+int main()
+{
+    ofstream fout(getenv("OUTPUT_PATH"));
+
+    string year_temp;
+    getline(cin, year_temp);
+
+    int year = stoi(ltrim(rtrim(year_temp)));
+
+    string result = dayOfProgrammer(year);
+
+    fout << result << "\n";
+
+    fout.close();
+
+    return 0;
+}
+
+//function definition of ltrim
+string ltrim(const string &str) {
+    string s(str);
+
+    s.erase(
+        s.begin(),
+        find_if(s.begin(), s.end(), not1(ptr_fun<int, int>(isspace)))
+    );
+
+    return s;
+}
+
+//function definition of rtrim
+string rtrim(const string &str) {
+    string s(str);
+
+    s.erase(
+        find_if(s.rbegin(), s.rend(), not1(ptr_fun<int, int>(isspace))).base(),
+        s.end()
+    );
+
+    return s;
+}


### PR DESCRIPTION
## Related Issue
  - Marie invented a Time Machine and wants to test it by time-traveling to visit Russia on the Day of the Programmer (the 256th day of the year) during a year in the inclusive range from 1700 to 2700.

From 1700 to 1917, Russia's official calendar was the Julian calendar; since 1919 they used the Gregorian calendar system. The transition from the Julian to Gregorian calendar system occurred in 1918, when the next day after January 31st was February 14th. This means that in 1918, February 14th was the 32nd day of the year in Russia.

In both calendar systems, February is the only month with a variable amount of days; it has 29 days during a leap year, and 28 days during all other years. In the Julian calendar, leap years are divisible by 4; in the Gregorian calendar, leap years are either of the following:

Divisible by 400.
Divisible by 4 and not divisible by 100.
Given a year, , find the date of the 256th day of that year according to the official Russian calendar during that year. Then print it in the format dd.mm.yyyy, where dd is the two-digit day, mm is the two-digit month, and yyyy is .

For example, the given  = 1984. 1984 is divisible by 4, so it is a leap year. The 256th day of a leap year after 1918 is September 12, so the answer is .

Function Description
Complete the dayOfProgrammer function in the editor below. It should return a string representing the date of the 256th day of the year given.

dayOfProgrammer has the following parameter(s):

year: an integer
Input Format

A single integer denoting year .

Constraints:
1700 \le y \le 2700

Output Format
Print the full date of Day of the Programmer during year  in the format dd.mm.yyyy, where dd is the two-digit day, mm is the two-digit month, and yyyy is .

Sample Input 0
2017

Sample Output 0
13.09.2017

Explanation 0
In the year  = 2017, January has 31 days, February has 28 days, March has 31 days, April has 30 days, May has 31 days, June has 30 days, July has 31 days, and August has 31 days. When we sum the total number of days in the first eight months, we get 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 = 243. Day of the Programmer is the 256th day, so then calculate 256 - 243 = 13 to determine that it falls on day 13 of the 9th month (September). We then print the full date in the specified format, which is 13.09.2017.

Sample Input 1
2016

Sample Output 1
12.09.2016

Explanation 1
Year  = 2016 is a leap year, so February has 29 days but all the other months have the same number of days as in 2017. When we sum the total number of days in the first eight months, we get 31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 = 244. Day of the Programmer is the 256th day, so then calculate 256 - 244 = 12 to determine that it falls on day 12 of the 9th month (September). We then print the full date in the specified format, which is 12.09.2016.

Sample Input 2
1800

Sample Output 2
12.09.1800

Explanation 2
Since 1800 is leap year as per Julian calendar. Day lies on 12 September.


Closes: #99

### Describe the changes you've made
I have given a solution of this problem in c++.

### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

### Language used for coding
C++

### Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ x] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have made corresponding changes to the documentation.
- [ x] New and existing unit tests pass locally with my changes.
